### PR TITLE
Fix Player->getSession

### DIFF
--- a/HypixelPHP.php
+++ b/HypixelPHP.php
@@ -727,7 +727,7 @@ class HypixelPHP
 
     /**
      * Function to get and cache UUID from username.
-     * @param        $username
+     * @param string $username
      * @param string $url
      *
      * @return string|bool
@@ -742,9 +742,6 @@ class HypixelPHP
             $timestamp = array_key_exists('timestamp', $content) ? $content['timestamp'] : 0;
             if (time() - $this->getCacheTime('uuid') < $timestamp) {
                 if (isset($content['uuid'])) return $content['uuid'];
-            } else {
-                $this->debug(time() - $this->getCacheTime('uuid'));
-                $this->debug($timestamp);
             }
         }
 
@@ -927,7 +924,7 @@ class Player extends HypixelObject
      */
     public function getSession()
     {
-        return $this->api->getSession(array('player' => $this->getName()));
+        return $this->api->getSession(array('player' => $this));
     }
 
     /**

--- a/HypixelPHP.php
+++ b/HypixelPHP.php
@@ -487,6 +487,30 @@ class HypixelPHP
                         $this->setCache($filename, $FRIENDS);
                         return $FRIENDS;
                     }
+                } else if ($key == 'uuid') {
+
+                    // Todo make it that when using Player->getFriends() it uses the UUID.
+
+                    /* @var $val Player */
+                    $filename = $this->options['cache_folder_friends'] . DIRECTORY_SEPARATOR . $key . DIRECTORY_SEPARATOR . $this->getCacheFileName($val->getName()) . '.json';
+                    $content  = $this->getCache($filename);
+                    if ($content != null) {
+                        $timestamp = array_key_exists('timestamp', $content) ? $content['timestamp'] : 0;
+                        if (time() - $this->getCacheTime() < $timestamp) {
+                            return new Friends($content, $this);
+                        }
+                    }
+
+                    $response = $this->fetch('friends', $key, $val->getUUID());
+                    if ($response['success'] == 'true') {
+                        $FRIENDS = new Friends(array(
+                            'record' => $response['records'],
+                            'extra'  => $content['extra']
+                        ), $this);
+                        $FRIENDS->setExtra(array('filename' => $filename));
+                        $this->setCache($filename, $FRIENDS);
+                        return $FRIENDS;
+                    }
                 }
             }
         }

--- a/HypixelPHP.php
+++ b/HypixelPHP.php
@@ -933,7 +933,7 @@ class Player extends HypixelObject
      */
     public function getFriends()
     {
-        return $this->api->getFriends(array('player' => $this->getName()));
+        return $this->api->getFriends(array('player' => $this));
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To interact with the API you need an API key, you can get a key by doing "/api" 
 $HypixelAPI = new HypixelAPI(array(
     'api_key' => '',
     'cache_time' => 600,
+    'cache_uuid_time' => 864000,
     'timeout' => 2,
     'cache_folder_player' => $_SERVER['DOCUMENT_ROOT'] . '/cache/HypixelAPI/player',
     'cache_folder_guild' => $_SERVER['DOCUMENT_ROOT'] . '/cache/HypixelAPI/guild',


### PR DESCRIPTION
I have fixed a problem with the getSession function. The ``api->getSession`` function expects a ``Player`` object, to use ``getName()`` on, not a string.
I also fixed the README.