### PR TITLE
Fix exception on using array_key_exists with a null variable.

### DIFF
--- a/HypixelPHP.php
+++ b/HypixelPHP.php
@@ -713,6 +713,9 @@ class HypixelPHP
             return null;
         }
         $content = json_decode($content, true);
+        if ($content == null) {
+            return null;
+        }
         if (!array_key_exists('extra', $content)) {
             $content['extra'] = [];
         }


### PR DESCRIPTION
Sometimes, I received an error due to ``array_key_exists`` being used when ``$content`` is null. This is weird, but happens whenever php cannot ``json_decode()`` something for whatever reason, then it just returns null. It's best to check for this unexpected behavior than getting an error :+1: 

It may not look so great (copy of a few lines), but I don't think it will have any impact on performance.