### PR TITLE
Hotfix since API always returns true in case of valid guild ID

### DIFF
--- a/HypixelPHP/HypixelPHP.php
+++ b/HypixelPHP/HypixelPHP.php
@@ -355,7 +355,7 @@ class HypixelPHP {
                     }
 
                     $response = $this->fetch(API_REQUESTS::FIND_GUILD, $key, $val, 5000);
-                    if ($response['success'] == true) {
+                    if ($response['success'] == true && isset($response['guild'])) {
                         $content = ['timestamp' => time(), 'guild' => $response['guild']];
                         $this->setFileContent($filename, json_encode($content));
                         return $this->getGuild([KEYS::GUILD_BY_ID => $response['guild']]);

--- a/HypixelPHP/HypixelPHP.php
+++ b/HypixelPHP/HypixelPHP.php
@@ -372,7 +372,7 @@ class HypixelPHP {
                     }
 
                     $response = $this->fetch(API_REQUESTS::GUILD, $key, $val);
-                    if ($response['success'] == true) {
+                    if ($response['success'] == true && isset($response['guild'])) {
                         $GUILD = new Guild([
                             'record' => $response['guild'],
                             'extra' => $content['extra']


### PR DESCRIPTION
Not sure if this is only a temporary API issue, but the guild field is omitted from the response if the requested ID does not exist.