### PR TITLE
Bugfix: Requesting guild from player object

### DIFF
--- a/src/HypixelPHP.php
+++ b/src/HypixelPHP.php
@@ -412,7 +412,7 @@ class HypixelPHP {
                     if ($id instanceof Guild) {
                         return $id;
                     } else {
-                        return $this->getGuild([FetchParams::GUILD_BY_ID => $id]);
+                        return $this->getGuild([FetchParams::GUILD_BY_ID => $id['guild']]);
                     }
                 }
 


### PR DESCRIPTION
I noticed that guild tags were working when requesting a player when the player has not been cached yet, but any requests following that one caused some errors to show up and the guild to be null. Requesting the guild with ID being an array instead of a string (from that array) was the cause.