### PR TITLE
Bugfix: Guild cache is not respected when requesting a guild via UUID or name

### DIFF
--- a/src/cache/impl/FlatFileCacheHandler.php
+++ b/src/cache/impl/FlatFileCacheHandler.php
@@ -169,7 +169,7 @@ class FlatFileCacheHandler extends CacheHandler {
             $cacheTime = $this->getCacheTime(CacheTimes::GUILD_NOT_FOUND);
         }
         $timestamp = array_key_exists('timestamp', $cached) ? $cached['timestamp'] : 0;
-        if (CacheUtil::isExpired($timestamp, $cacheTime)) return null;
+        if (CacheUtil::isExpired($timestamp * 1000, $cacheTime * 1000)) return null;
         return $cached['guild'];
     }
 
@@ -197,7 +197,7 @@ class FlatFileCacheHandler extends CacheHandler {
         }
 
         $timestamp = array_key_exists('timestamp', $cached) ? $cached['timestamp'] : 0;
-        if (CacheUtil::isExpired($timestamp, $cacheTime)) return null;
+        if (CacheUtil::isExpired($timestamp * 1000, $cacheTime * 1000)) return null;
         return $cached['guild'];
     }
 


### PR DESCRIPTION
The method `CacheUtil::isExpired` compares timestamps in order to validate if a timestamp is older than allowed, defined by a given cache time. Both the timestamp and cache time should be in milliseconds, but were given in seconds, therefore always yielding `true` as a result, breaking the caching.