### PR TITLE
Bug fix for levels that are multiples of 100

### DIFF
--- a/src/util/games/bedwars/ExpCalculator.php
+++ b/src/util/games/bedwars/ExpCalculator.php
@@ -43,7 +43,7 @@ class ExpCalculator {
 
         $expWithoutPrestiges = $exp - ($prestiges * self::XP_PER_PRESTIGE);
         for ($i = 1; $i <= self::EASY_LEVELS; ++$i) {
-            $expForEasyLevel = self::getExpForLevel($i);
+            $expForEasyLevel = self::getExpForLevelFromPrevLevelOfPres($i);
             if ($expWithoutPrestiges < $expForEasyLevel) {
                 break;
             }
@@ -55,10 +55,10 @@ class ExpCalculator {
         return $level;
     }
 
-    public function getExpForLevel($level) {
-        if ($level == 0) return 0;
-
+    public function getExpForLevelFromPrevLevelOfPres($level) {
         $respectedLevel = self::getLevelRespectingPrestige($level);
+        if ($respectedLevel == 0) return 0;
+
         if ($respectedLevel <= self::EASY_LEVELS) {
             return self::EASY_LEVELS_XP[$respectedLevel - 1];
         }


### PR DESCRIPTION
When finding the exp from one level to the next, handle cases where the latter is a multiple of 100. Currently in master the program tries to use an index of -1 for such levels.